### PR TITLE
feat: EXP-789 Allow users to click ESC to exit full screen mode

### DIFF
--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -2,6 +2,7 @@ import { sendMessageToTestBox } from "./messaging";
 import { addFullStory } from "./fullstory";
 import {
   CLICK,
+  EXIT_FULLSCREEN,
   HEALTH_CHECK,
   INITIALIZE_ACK,
   INITIALIZE_FAIL,
@@ -15,6 +16,7 @@ export function initializeTestBox(data: InitializeEvent) {
     sendMessageToTestBox(INITIALIZE_ACK);
     initializeCookies();
     rewriteLinks();
+    enhanceFullscreenExperience();
     startHealthChecks();
 
     if (data.optInFullStory && getConfigItem("allowFullStory")) {
@@ -47,6 +49,20 @@ function initializeCookies() {
   (document as any).__defineSetter__("cookie", setCookieOverride);
   // Re-sets the getter as it gets lost during the seter overwrite
   (document as any).__defineGetter__("cookie", nativeCookieGetter);
+}
+
+function enhanceFullscreenExperience() {
+  const ESCAPE_KEYS = ["27", "Escape"];
+
+  window.addEventListener(
+    "keydown",
+    ({ key }: KeyboardEvent) => {
+      if (ESCAPE_KEYS.includes(String(key))) {
+        sendMessageToTestBox(EXIT_FULLSCREEN);
+      }
+    },
+    false
+  );
 }
 
 function rewriteLinks() {

--- a/src/messaging/outgoing.ts
+++ b/src/messaging/outgoing.ts
@@ -1,5 +1,6 @@
 export const HEALTH_CHECK = "health-check";
 export const CLICK = "click";
+export const EXIT_FULLSCREEN = "exit-fullscreen";
 
 export const INITIALIZE_REQUEST = "initialize-request";
 export const RESET_IFRAME_REQUEST = "reset-iframe-request";
@@ -42,4 +43,5 @@ export interface TestBoxOutgoingEvents {
   [LOGIN_FAIL]: LoginFailEvent;
   [LOGIN_NO_CREDS]: undefined;
   [NAVIGATE_ACK]: undefined;
+  [EXIT_FULLSCREEN]: undefined;
 }


### PR DESCRIPTION
# Why this change?
while testing a product, the iframe has the focus, so key events can not be processed by tb. this will inject the code needed to capture the `esc` key so that the appropriate event (`exit-fullscreen`) can be sent to the iframe's parent. 