### PR TITLE
[CAP-78] - feat: add SDK start block logic when extension is active

### DIFF
--- a/cypress/cdn.test.ts
+++ b/cypress/cdn.test.ts
@@ -2,31 +2,43 @@ import { registerLoginHandler, startTestBox } from "../src/index";
 
 declare global {
   interface Window {
-    test_fakeLoginHandler: (props) => Promise<string | boolean>;
-    test_fakeNavigateHandler: (data) => void;
+    test_fakeLoginHandler: (props: any) => Promise<string | boolean>;
+    test_fakeNavigateHandler: (data: any) => void;
     test_startTestBox: any;
     test_registerLoginHandler: any;
     test_baseTbxConfig: {
       targetOrigin: string;
       allowFullStory: boolean;
-    }
+    };
   }
 }
 
-async function fakeLoginHandler(props) {
+async function fakeLoginHandler(props: any): Promise<string | boolean> {
   console.log("Fake login handler called with", props);
-  return true
+  return true;
 }
 
-function fakeNavigateHandler(data) {
-  return true
+async function fakeNavigateHandler(data: any): Promise<void | boolean> {
+  console.log("Fake navigate handler called with", data);
+  return true;
 }
 
 window.test_fakeLoginHandler = fakeLoginHandler;
-window.test_fakeNavigateHandler = fakeNavigateHandler
-window.test_startTestBox = startTestBox
-window.test_registerLoginHandler = registerLoginHandler
+window.test_fakeNavigateHandler = fakeNavigateHandler;
+window.test_startTestBox = startTestBox;
+window.test_registerLoginHandler = registerLoginHandler;
 window.test_baseTbxConfig = {
   targetOrigin: "localhost",
-  allowFullStory: true
-}
+  allowFullStory: true,
+};
+
+// tbxConfig
+const config = {
+  navigateHandler: window.test_fakeNavigateHandler,
+  loginHandler: window.test_fakeLoginHandler,
+  logLevel: "error",
+  ...window.test_baseTbxConfig,
+};
+
+// @ts-ignore
+// startTestBox(config);

--- a/cypress/cdn.test.ts
+++ b/cypress/cdn.test.ts
@@ -31,14 +31,3 @@ window.test_baseTbxConfig = {
   targetOrigin: "localhost",
   allowFullStory: true,
 };
-
-// tbxConfig
-const config = {
-  navigateHandler: window.test_fakeNavigateHandler,
-  loginHandler: window.test_fakeLoginHandler,
-  logLevel: "error",
-  ...window.test_baseTbxConfig,
-};
-
-// @ts-ignore
-// startTestBox(config);

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -6,12 +6,14 @@ const spyLoginHandler = (win) => {
   cy.spy(win, "test_fakeLoginHandler").as("loginHandlerSpy");
 };
 const spyNavigateHandler = (win) => {
-  cy.spy(win, "test_fakeNavigateHandler").as("navigateHandlerSpy")
-}
+  cy.spy(win, "test_fakeNavigateHandler").as("navigateHandlerSpy");
+};
 
 const loginHandlerStub = (win, returnValue) => {
-  cy.stub(win, "test_fakeLoginHandler").as("loginHandlerStub").callsFake(() => returnValue)
-}
+  cy.stub(win, "test_fakeLoginHandler")
+    .as("loginHandlerStub")
+    .callsFake(() => returnValue);
+};
 
 const assertInitializeCall = () =>
   cy.get("@postMessage").should(
@@ -39,9 +41,8 @@ const fakeLoginMessage = () => ({
       last_name: "User 1",
     },
   },
-  }
-)
-const fakeLoginMessageStringified = JSON.stringify(fakeLoginMessage())
+});
+const fakeLoginMessageStringified = JSON.stringify(fakeLoginMessage());
 
 describe("testbox script", () => {
   it("Sends initialize to TestBox", () => {
@@ -74,7 +75,10 @@ describe("testbox script", () => {
       win.eval(`postMessage(${fakeLoginMessageStringified})`);
     });
 
-    cy.get("@loginHandlerSpy").should("have.been.calledOnceWith", fakeLoginMessage().testbox.data);
+    cy.get("@loginHandlerSpy").should(
+      "have.been.calledOnceWith",
+      fakeLoginMessage().testbox.data
+    );
   });
 
   it("Login handler register after login message", () => {
@@ -92,10 +96,15 @@ describe("testbox script", () => {
     cy.window().then((win) => {
       win.eval(`
         postMessage(${fakeLoginMessageStringified});`);
-      win.eval("window.test_registerLoginHandler(window.test_fakeLoginHandler);");
+      win.eval(
+        "window.test_registerLoginHandler(window.test_fakeLoginHandler);"
+      );
     });
 
-    cy.get("@loginHandlerSpy").should("have.been.calledOnceWith", fakeLoginMessage().testbox.data);
+    cy.get("@loginHandlerSpy").should(
+      "have.been.calledOnceWith",
+      fakeLoginMessage().testbox.data
+    );
   });
 
   it("Login handler register before login message", () => {
@@ -111,35 +120,46 @@ describe("testbox script", () => {
     assertInitializeCall();
 
     cy.window().then((win) => {
-      win.eval("window.test_registerLoginHandler(window.test_fakeLoginHandler);");
+      win.eval(
+        "window.test_registerLoginHandler(window.test_fakeLoginHandler);"
+      );
       win.eval(`
         postMessage(${fakeLoginMessageStringified});`);
     });
 
-    cy.get("@loginHandlerSpy").should("have.been.calledOnceWith", fakeLoginMessage().testbox.data);
+    cy.get("@loginHandlerSpy").should(
+      "have.been.calledOnceWith",
+      fakeLoginMessage().testbox.data
+    );
   });
 
   it("Navigate handler is called for login handler return url", () => {
-    const fakeRedirectUrl = "https://fakeurl.com/success"
+    const fakeRedirectUrl = "https://fakeurl.com/success";
     cy.visit(BASE_URL, {
       onBeforeLoad: spyPostMessage,
       onLoad: (win) => {
-        loginHandlerStub(win, fakeRedirectUrl)
-        spyNavigateHandler(win)
+        loginHandlerStub(win, fakeRedirectUrl);
+        spyNavigateHandler(win);
       },
     });
 
     cy.window().then((win) => {
-      win.eval(`test_startTestBox({...window.test_baseTbxConfig, window: window.parent, navigateHandler: window.test_fakeNavigateHandler });`);
+      win.eval(
+        `test_startTestBox({...window.test_baseTbxConfig, window: window.parent, navigateHandler: window.test_fakeNavigateHandler });`
+      );
     });
 
-     cy.window().then((win) => {
-      win.eval("window.test_registerLoginHandler(window.test_fakeLoginHandler);");
+    cy.window().then((win) => {
+      win.eval(
+        "window.test_registerLoginHandler(window.test_fakeLoginHandler);"
+      );
       win.eval(`
         postMessage(${fakeLoginMessageStringified});`);
     });
 
-    cy.get("@navigateHandlerSpy").should("have.been.calledWith", {url: fakeRedirectUrl});
+    cy.get("@navigateHandlerSpy").should("have.been.calledWith", {
+      url: fakeRedirectUrl,
+    });
   });
 
   it("LoginHandler should send login-failed message in case of error", () => {
@@ -149,23 +169,27 @@ describe("testbox script", () => {
     });
 
     cy.window().then((win) => {
-      win.eval(`test_startTestBox({...window.test_baseTbxConfig, window: window.parent });`);
+      win.eval(
+        `test_startTestBox({...window.test_baseTbxConfig, window: window.parent });`
+      );
     });
 
-     cy.window().then((win) => {
-      win.eval("window.test_registerLoginHandler(window.test_fakeLoginHandler);");
+    cy.window().then((win) => {
+      win.eval(
+        "window.test_registerLoginHandler(window.test_fakeLoginHandler);"
+      );
       win.eval(`
         postMessage(${fakeLoginMessageStringified});`);
     });
 
     cy.get("@postMessage").should("have.been.calledWith", {
-     testbox: {
-       version: 1,
-       event: "login-fail",
-       data: { message: undefined },
-       sender: "partner"
-      }
-    })
+      testbox: {
+        version: 1,
+        event: "login-fail",
+        data: { message: undefined },
+        sender: "partner",
+      },
+    });
   });
 
   it("LoginHandler should send login-success message in case of success", () => {
@@ -181,69 +205,80 @@ describe("testbox script", () => {
     assertInitializeCall();
 
     cy.window().then((win) => {
-      win.eval("window.test_registerLoginHandler(window.test_fakeLoginHandler);");
+      win.eval(
+        "window.test_registerLoginHandler(window.test_fakeLoginHandler);"
+      );
       win.eval(`
         postMessage(${fakeLoginMessageStringified});`);
     });
 
     cy.get("@postMessage").should("have.been.calledWith", {
-     testbox: {
-       version: 1,
-       event: "login-success",
-       data: undefined,
-       sender: "partner"
-      }
-    })
-
+      testbox: {
+        version: 1,
+        event: "login-success",
+        data: undefined,
+        sender: "partner",
+      },
+    });
   });
 
   it("registerLoginHandler should display warning if registered more than once", () => {
     cy.visit(BASE_URL, {
       onBeforeLoad: spyPostMessage,
       onLoad: (win) => {
-        spyLoginHandler(win)
-        cy.spy(win.console, 'warn').as("warnSpy")
+        spyLoginHandler(win);
+        cy.spy(win.console, "warn").as("warnSpy");
       },
     });
 
     cy.window().then((win) => {
-      win.eval(`test_startTestBox({...window.test_baseTbxConfig, logLevel: "warn"});`);
+      win.eval(
+        `test_startTestBox({...window.test_baseTbxConfig, logLevel: "warn"});`
+      );
     });
 
     assertInitializeCall();
 
     cy.window().then((win) => {
-      win.eval("window.test_registerLoginHandler(window.test_fakeLoginHandler);");
-      win.eval("window.test_registerLoginHandler(window.test_fakeLoginHandler);");
+      win.eval(
+        "window.test_registerLoginHandler(window.test_fakeLoginHandler);"
+      );
+      win.eval(
+        "window.test_registerLoginHandler(window.test_fakeLoginHandler);"
+      );
     });
 
-    cy.get("@warnSpy").should("have.been.calledOnceWith", JSON.stringify({"event":"Login handler already registered!"}))
+    cy.get("@warnSpy").should(
+      "have.been.calledOnceWithExactly",
+      "[TBX SDK]: Login handler already registered!"
+    );
   });
 
   it("Login event waiting for more than 10 seconds should send error message", () => {
-     cy.visit(BASE_URL, {
-       onBeforeLoad: spyPostMessage,
-       onLoad: spyLoginHandler,
-     });
+    cy.visit(BASE_URL, {
+      onBeforeLoad: spyPostMessage,
+      onLoad: spyLoginHandler,
+    });
 
-     cy.window().then((win) => {
-       win.eval(`test_startTestBox({...window.test_baseTbxConfig, window: window.parent });`);
-     });
+    cy.window().then((win) => {
+      win.eval(
+        `test_startTestBox({...window.test_baseTbxConfig, window: window.parent });`
+      );
+    });
 
-     cy.window().then((win) => {
-       win.eval(`
-         postMessage(${fakeLoginMessageStringified});`);
-     })
+    cy.window().then((win) => {
+      win.eval(`postMessage(${fakeLoginMessageStringified});`);
+    });
 
-     cy.wait(10500)
+    cy.wait(10500);
 
-     cy.get("@postMessage").should("have.been.calledWith", {
-       testbox: {
-         version: 1,
-         event: "login-fail",
-         data: { message: "Failed to log in." },
-         sender: "partner"
-       }
-     })
-   })
+    cy.get("@postMessage").should("have.been.calledWith", {
+      testbox: {
+        version: 1,
+        sender: "partner",
+        event: "login-fail",
+        data: { message: "Failed to log in." },
+      },
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
-    "test": "npm run build && cypress",
+    "test": "npm run build && cypress open",
     "dev": "webpack serve --mode development --config ./webpack.config.js",
     "build": "tsc && esbuild --bundle --minify --outfile=static/cdn.js cypress/cdn.test.ts",
     "prepare": "husky install",

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,8 +17,8 @@ export interface TestBoxConfig {
   loginEventFallbackInMilliseconds?: number;
   linkTargetLoopInterval?: number;
   healthCheckInterval?: number;
+  startedByExtension?: boolean;
   window?: Window;
-
   navigateHandler?: (url: NavigateEvent) => Promise<void>;
 }
 
@@ -26,6 +26,7 @@ declare global {
   interface Window {
     __tbxConfig?: TestBoxConfig;
     __tbxLoginEvent?: LoginMessage;
+    __tbxExtensionActive?: boolean;
   }
 }
 
@@ -34,7 +35,7 @@ export function getTargetOrigin() {
 }
 
 export function getLogLevel() {
-  return window.__tbxConfig.logLevel || "none";
+  return window.__tbxConfig?.logLevel || "none";
 }
 
 export function getConfigItem<K extends keyof TestBoxConfig>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export function startTestBox(config?: TestBoxConfig) {
 
   if (window.__tbxExtensionActive && !config.startedByExtension) {
     // Checking for Extension
-    info(
+    warn(
       "Extension is Active and SDK start had a different origin. Blocking SDK start"
     );
     return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { INITIALIZE_REQUEST } from "./messaging/outgoing";
 import { LoginEvent, NavigateEvent } from "./messaging/incoming";
 import { messageHandler } from "./message-event";
 import { routeMessage } from "./router";
-import { warn } from "./utils/logging";
+import { info, warn } from "./utils/logging";
 
 let tbxStarted = false;
 
@@ -23,7 +23,7 @@ export async function registerLoginHandler(newLoginHandler: LoginHandler) {
 
   if (!tbxStarted) {
     throw new Error(
-      "StartTestbox function must be called before registering login handler!"
+      "startTestBox function must be called before registering login handler!"
     );
   }
 
@@ -43,13 +43,25 @@ export async function registerLoginHandler(newLoginHandler: LoginHandler) {
 }
 
 export function startTestBox(config?: TestBoxConfig) {
+  // Verifications
   if (tbxStarted) {
+    info("SDK already started");
     return;
   }
 
   window.__tbxConfig = config;
-  window.__tbxLoginEvent = null;
+  info("Starting SDK...");
 
+  if (window.__tbxExtensionActive && !config.startedByExtension) {
+    // Checking for Extension
+    info(
+      "Extension is Active and SDK start had a different origin. Blocking SDK start"
+    );
+    return;
+  }
+
+  // Handlers
+  window.__tbxLoginEvent = null;
   if (window.__tbxConfig.navigateHandler) {
     navigateHandler = window.__tbxConfig.navigateHandler;
   } else {
@@ -63,9 +75,9 @@ export function startTestBox(config?: TestBoxConfig) {
   }
 
   window.addEventListener("message", messageEventCallback);
-
   sendMessageToTestBox(INITIALIZE_REQUEST);
   tbxStarted = true;
+  info("SDK Started!");
 }
 
 export const start = startTestBox;

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -24,26 +24,38 @@ function logLevel() {
   throw Error("No log level known");
 }
 
-export function info(event: string, ...payload: any) {
+export function info(event: string, payload?: Object) {
   if (logLevel() >= LogLevel.info) {
-    console.info(JSON.stringify({ event, ...payload }));
+    let logContent: string = payload
+      ? JSON.stringify({ event, ...payload })
+      : event;
+    console.info(`[TBX SDK]: ${logContent}`);
   }
 }
 
-export function debug(event: string, ...payload: any) {
+export function debug(event: string, payload?: Object) {
   if (logLevel() >= LogLevel.debug) {
-    console.debug(JSON.stringify({ event, ...payload }));
+    let logContent: string = payload
+      ? JSON.stringify({ event, ...payload })
+      : event;
+    console.debug(`[TBX SDK]: ${logContent}`);
   }
 }
 
-export function warn(event: string, ...payload: any) {
+export function warn(event: string, payload?: Object) {
   if (logLevel() >= LogLevel.warn) {
-    console.warn(JSON.stringify({ event, ...payload }));
+    let logContent: string = payload
+      ? JSON.stringify({ event, ...payload })
+      : event;
+    console.warn(`[TBX SDK]: ${logContent}`);
   }
 }
 
-export function error(event: string, ...payload: any) {
+export function error(event: string, payload?: Object) {
   if (logLevel() >= LogLevel.error) {
-    console.error(JSON.stringify({ event, ...payload }));
+    let logContent: string = payload
+      ? JSON.stringify({ event, ...payload })
+      : event;
+    console.error(`[TBX SDK]: ${logContent}`);
   }
 }

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -2,10 +2,10 @@ import { getLogLevel } from "../config";
 
 export enum LogLevel {
   none = 0,
-  debug = 1,
-  info = 2,
-  warn = 3,
-  error = 4,
+  error = 1,
+  warn = 2,
+  info = 3,
+  debug = 4,
 }
 
 function logLevel() {

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,8 @@
 <html>
     <head>
-        <script type="text/javascript" src="./cdn.js"></script>
+        <script type="text/javascript" src="./static/cdn.js"></script>
     </head>
+    <body>
+        <h1>SDK Testing Grounds</h1>
+    </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <script type="text/javascript" src="./static/cdn.js"></script>
+        <script type="text/javascript" src="./cdn.js"></script>
     </head>
     <body>
         <h1>SDK Testing Grounds</h1>


### PR DESCRIPTION
### What did I change:

- Implemented logic to block the SDK start when the Extension is active.
- Improved logging methods for TBX SDK.

### QA Notes:
QA Notes on Linear Task: https://linear.app/testbox/issue/CAP-78/[browser-sdk]-disable-load-when-extension-is-present

### Related Tickets:
https://linear.app/testbox/issue/CAP-78/[browser-sdk]-disable-load-when-extension-is-present

### Did you...
- [x] test the code locally?
- [x] run unit tests and updated to account for the changes?
- [x] lint the code?
- [x] format the code?
- [x] test the code on staging?
